### PR TITLE
Ecs fix (#478)

### DIFF
--- a/Source/MonoGame.Extended.Entities/EntityManager.cs
+++ b/Source/MonoGame.Extended.Entities/EntityManager.cs
@@ -337,14 +337,12 @@ namespace MonoGame.Extended.Entities
         {
             Debug.Assert(entity != null);
             Debug.Assert(componentType != null);
-            Debug.Assert(componentType.Index < _componentTypeEntitiesToComponents.Count);
 
             var components = _componentTypeEntitiesToComponents[componentType.Index];
 
-            Debug.Assert(components != null);
 
-            EntityComponent component;
-            components.TryGetValue(entity, out component);
+            EntityComponent component = null;
+            components?.TryGetValue(entity, out component);
             return component;
         }
 
@@ -403,14 +401,11 @@ namespace MonoGame.Extended.Entities
                 if (components == null)
                     continue;
 
-                object component;
-
                 EntityComponent component;
                 if (!components.TryGetValue(entity, out component))
                     continue;
 
                 components.Remove(entity);
-                component.Return();
             }
         }
 


### PR DESCRIPTION
* Implemented GuiResizableControl, and made GuiWindowControl inherit from it.

GuiResizableControl is a control that can be resized.

GuiResizableControl calls SetCursorForResize(_resizingSides), which can be overriden to provide platform specific mouse cursor implementation depending on where on the edge of the control your mouse is.

* Screen Desktop defaulted to being width of 1, and height of 1, instead of width of 100%, and height of 100%

* Including class reference in project

* Implemented Size3 and Point3.  Fixed bug in Point2.  Documentation listed Point2, but code took in Vector2.  Changed to Point2

* Adding missed project references

* Fixed assert errors: https://github.com/craftworkgames/MonoGame.Extended/issues/474

* Fix merge issue